### PR TITLE
chore: add 4 issue templates + customer-priority-bump reusable workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,55 @@
+name: 🐛 Bug
+description: Report a defect or regression
+labels: ["work-type:bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line summary of what's broken
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps anyone can follow
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "S1 — Production down / data loss"
+        - "S2 — Feature broken / no workaround"
+        - "S3 — Feature degraded / workaround exists"
+        - "S4 — Cosmetic / minor"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: "dev / staging / prod / all"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots / video
+      description: Attach evidence

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Engineering Slack
+    url: https://tracebloc.slack.com/
+    about: For quick questions, discussions, or things that aren't a tracked work item yet.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,22 @@
+name: 📚 Documentation
+description: Missing, incorrect, or stale documentation
+labels: ["work-type:docs"]
+body:
+  - type: textarea
+    id: gap
+    attributes:
+      label: What's missing or wrong
+    validations:
+      required: true
+  - type: textarea
+    id: audience
+    attributes:
+      label: Audience
+      description: Who needs this? (end-users, internal devs, customers, contributors…)
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Where it should live
+      placeholder: "docs.tracebloc.io / README / CLAUDE.md / blog"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,50 @@
+name: ✨ Feature
+description: Propose a new product capability
+labels: ["work-type:feature", "needs-refinement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for **new product capabilities**. For bugs, use the Bug template.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user/customer problem does this solve? Who's blocked?
+      placeholder: "Customers can't comply with GDPR right-to-erasure because…"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Bullet list of testable conditions for "done"
+      placeholder: |
+        - When user clicks Delete Account, all their data is removed within 30 days
+        - User receives confirmation email with rollback option for 7 days
+        - Deletion is logged for compliance audit
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What is explicitly NOT included? Future tickets to consider.
+      placeholder: "Bulk delete (separate ticket); admin-initiated deletion (separate ticket)"
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test plan
+      description: How will we verify this works?
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority (best guess — refiner can change)
+      options:
+        - "P1 — High (blocks customer or team)"
+        - "P2 — Normal"
+        - "P3 — Nice-to-have"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,29 @@
+name: 🧹 Tech debt
+description: Refactor / cleanup with no behavior change
+labels: ["work-type:tech-debt", "needs-refinement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs cleanup
+      placeholder: "Backend has 3 different database connection patterns…"
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now
+      description: What does this unlock? What's the cost of leaving it?
+    validations:
+      required: true
+  - type: textarea
+    id: blast-radius
+    attributes:
+      label: Blast radius
+      description: What might break? What needs careful review?
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope

--- a/.github/workflows/customer-priority-bump.yml
+++ b/.github/workflows/customer-priority-bump.yml
@@ -1,0 +1,89 @@
+name: Bump priority on customer-flagged issue
+
+# Reusable workflow. Called from each active repo on any issue label change.
+# When the 'from:customer' label is applied, sets Priority=P1 on the kanban.
+
+on:
+  workflow_call:
+    inputs:
+      project-number:
+        type: number
+        default: 2
+      org:
+        type: string
+        default: tracebloc
+      target-priority:
+        type: string
+        default: "P1"
+      trigger-label:
+        type: string
+        default: "from:customer"
+
+jobs:
+  bump:
+    if: github.event.label.name == inputs.trigger-label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Priority for the customer issue
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_KANBAN_TOKEN }}
+          ORG: ${{ inputs.org }}
+          PROJECT_NUMBER: ${{ inputs.project-number }}
+          PRIORITY_NAME: ${{ inputs.target-priority }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO_FULL: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          REPO_NAME="${REPO_FULL#*/}"
+
+          PROJ=$(gh api graphql -f query='
+            query($org: String!, $num: Int!) {
+              organization(login: $org) {
+                projectV2(number: $num) {
+                  id
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField { id name options { id name } }
+                    }
+                  }
+                }
+              }
+            }' -F org="$ORG" -F num="$PROJECT_NUMBER")
+
+          PROJECT_ID=$(echo "$PROJ" | jq -r '.data.organization.projectV2.id')
+          PRIORITY_FIELD=$(echo "$PROJ" | jq -r '.data.organization.projectV2.fields.nodes[]
+            | select(.name=="Priority") | .id')
+          PRIORITY_OPT=$(echo "$PROJ" | jq -r --arg p "$PRIORITY_NAME" '.data.organization.projectV2.fields.nodes[]
+            | select(.name=="Priority") | .options[] | select(.name==$p) | .id')
+
+          # Wait briefly for auto-add to register the issue on the project
+          for i in 1 2 3 4 5; do
+            ITEM_ID=$(gh api graphql -f query='
+              query($org: String!, $repo: String!, $num: Int!) {
+                repository(owner: $org, name: $repo) {
+                  issue(number: $num) {
+                    projectItems(first: 10) { nodes { id project { number } } }
+                  }
+                }
+              }' -F org="$ORG" -F repo="$REPO_NAME" -F num="$ISSUE_NUMBER" \
+              | jq -r --arg n "$PROJECT_NUMBER" '.data.repository.issue.projectItems.nodes[]?
+                  | select(.project.number == ($n | tonumber)) | .id' | head -1)
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then break; fi
+            echo "Issue not yet on project, retrying ($i/5)…"
+            sleep 5
+          done
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "Issue #$ISSUE_NUMBER not on project after 5 retries — skipping."
+            exit 0
+          fi
+
+          gh api graphql -f query='
+            mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $p, itemId: $i, fieldId: $f,
+                value: {singleSelectOptionId: $o}
+              }) { projectV2Item { id } }
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$PRIORITY_FIELD" -F o="$PRIORITY_OPT" > /dev/null
+
+          echo "→ Issue #$ISSUE_NUMBER bumped to Priority=$PRIORITY_NAME"


### PR DESCRIPTION
## Summary

Adds the org-wide issue intake structure and one supporting reusable workflow.

### Issue templates (`.github/ISSUE_TEMPLATE/`)
4 structured forms — Feature, Bug, Tech-debt, Docs — plus a `config.yml` that disables blank issues. Apply org-wide to any repo without its own templates. Each template enforces required fields (problem, AC, repro steps, severity, etc.) so even raw "capture" produces something refinable.

### Customer-priority-bump reusable workflow (`.github/workflows/customer-priority-bump.yml`)
Called by each active repo on issue label changes. When `from:customer` is applied, sets `Priority = P1` on the kanban automatically. Uses the existing `PROJECTS_KANBAN_TOKEN` org secret. Same shape as `advance-deploy-env.yml`.

## Activation

- Issue templates: active immediately on merge for any repo without its own `.github/ISSUE_TEMPLATE/`
- Customer-priority-bump: dormant until each repo opts in via a tiny caller workflow (rolling out separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)