### PR TITLE
ci: add set-pr-status caller for .github's own PRs

### DIFF
--- a/.github/workflows/set-pr-status-caller.yml
+++ b/.github/workflows/set-pr-status-caller.yml
@@ -1,0 +1,10 @@
+name: Set PR Status
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, converted_to_draft]
+
+jobs:
+  set-status:
+    uses: tracebloc/.github/.github/workflows/set-pr-status.yml@main
+    secrets: inherit


### PR DESCRIPTION
So PRs in `.github` itself get their kanban card moved to In review on open. Same caller as the other 16 active repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)