### PR TITLE
fix(advance-deploy-env): skip Status update if 'Done' can't be resolved

### DIFF
--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -102,6 +102,18 @@ jobs:
             exit 1
           fi
 
+          # Status update is a nice-to-have for prod pushes; degrade gracefully
+          # if the Status field or its "Done" option can't be resolved, rather
+          # than failing the whole workflow and masking the successful Deploy
+          # environment update.
+          if [ "$DEPLOY_ENV" = "prod" ]; then
+            if [ -z "$STATUS_FIELD" ] || [ "$STATUS_FIELD" = "null" ] \
+               || [ -z "$DONE_OPT" ]    || [ "$DONE_OPT" = "null" ]; then
+              echo "::warning::Could not resolve 'Done' option in Status field of project #$PROJECT_NUMBER — skipping Status updates"
+              SKIP_STATUS=1
+            fi
+          fi
+
           for prnum in ${{ steps.prs.outputs.prs }}; do
             # Defensive: if the number isn't a PR (e.g. issue ref slipped through),
             # the gh api call exits non-zero — swallow that and skip cleanly.
@@ -133,7 +145,7 @@ jobs:
                 }) { projectV2Item { id } }
               }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$DEPLOY_FIELD" -F o="$DEPLOY_OPT" > /dev/null
 
-            if [ "$DEPLOY_ENV" = "prod" ]; then
+            if [ "$DEPLOY_ENV" = "prod" ] && [ "${SKIP_STATUS:-0}" != "1" ]; then
               echo "→ PR #$prnum: Status = Done (prod)"
               gh api graphql -f query='
                 mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {


### PR DESCRIPTION
## Summary

Hardens `advance-deploy-env.yml` against missing Status field options.

The reusable workflow already validates `DEPLOY_OPT` before using it, but not `STATUS_FIELD` or `DONE_OPT`. When the lookup for "Done" returns nothing (option renamed, removed, or the field's name drifted), the GraphQL mutation receives an empty `$o` and the workflow crashes with:

```
gh: Variable $o of type String! was provided invalid value
```

This masks the fact that the primary `Deploy environment` update succeeded for every PR in the push. The team sees a red workflow and reasonably assumes the deploy didn't tag the kanban — when it actually did.

## What changes

1. After the field lookups, validate `STATUS_FIELD` and `DONE_OPT` (only when `env=prod`, since that's when Status gets touched). On miss, log a workflow `::warning::` and set `SKIP_STATUS=1`.
2. Gate the per-PR Status mutation on `${SKIP_STATUS:-0} != "1"`.

```bash
if [ "$DEPLOY_ENV" = "prod" ]; then
  if [ -z "$STATUS_FIELD" ] || [ "$STATUS_FIELD" = "null" ] \
     || [ -z "$DONE_OPT" ]    || [ "$DONE_OPT" = "null" ]; then
    echo "::warning::Could not resolve 'Done' option in Status field of project #$PROJECT_NUMBER — skipping Status updates"
    SKIP_STATUS=1
  fi
fi
```

## Behavior changes

- **Old**: missing "Done" → workflow fails, all subsequent PRs in the push are skipped, Deploy env update visible only by reading mid-run logs.
- **New**: missing "Done" → workflow warns, every PR's Deploy env update completes, Status update is skipped per-PR.
- **Non-prod pushes** (develop, staging): unchanged — Status was never touched on those.
- **Error message**: when something IS misconfigured, the warning identifies the project number and field name instead of a cryptic GraphQL error.

## Symmetry note

This matches the existing `DEPLOY_OPT` validation pattern — same shape, except graceful skip instead of abort because Status is a nice-to-have and Deploy env is the primary purpose of the workflow.

## Triggered by

[tracebloc/client run #24995200600](https://github.com/tracebloc/client/actions/runs/24995200600/job/73190255292) on PR #64 hit this exact failure: `Deploy env = prod` succeeded, then the Status mutation failed with the empty-`$o` error.

## Test plan

- [ ] After merge, re-run the failed `tracebloc/client` workflow (or wait for the next push to `main`) — confirm it completes green even if "Done" lookup returns empty.
- [ ] Manually break the lookup (rename "Done" to "DONE_TEMP" in project #2 briefly) and confirm the workflow still completes its Deploy environment updates and only skips Status with the expected warning.

Generated with [Claude Code](https://claude.com/claude-code)
