### PR TITLE
ci: add cron auto-classifier (Squad / Area / Deploy environment)

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -1,0 +1,109 @@
+name: Auto-classify kanban items (Squad / Area)
+
+# Scans the engineer kanban for items missing Squad classification and sets
+# Squad + Area based on the source repo. Closes the gap where auto-add only
+# sets Status=Backlog without populating downstream fields.
+#
+# Runs every 10 minutes. Idempotent — only touches items where Squad is unset.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find + classify unclassified items
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_KANBAN_TOKEN }}
+          PROJECT_NUMBER: 2
+          ORG: tracebloc
+        run: |
+          set -euo pipefail
+
+          # Repo → Squad option ID + Area option ID
+          declare -A SQUAD AREA
+          SQUAD[backend]=acd99fea;              AREA[backend]=43f88b89               # Backend/Platform · Backend API
+          SQUAD[averaging-service]=acd99fea;    AREA[averaging-service]=b5f63849     # Backend/Platform · Averaging
+          SQUAD[client]=acd99fea;               AREA[client]=b3b40fa4                # Backend/Platform · Client (Helm)
+          SQUAD[client-runtime]=acd99fea;       AREA[client-runtime]=beb42207        # Backend/Platform · Runtime
+          SQUAD[tracebloc-client]=e90f32ba;     AREA[tracebloc-client]=beb42207      # Data Science · Runtime
+          SQUAD[tracebloc-py-package]=e90f32ba; AREA[tracebloc-py-package]=ec7cf205  # Data Science · SDK
+          SQUAD[model-zoo]=e90f32ba;            AREA[model-zoo]=0140d45d             # Data Science · Model zoo
+          SQUAD[data-ingestors]=e90f32ba;       AREA[data-ingestors]=4cabb119        # Data Science · Data ingestion
+          SQUAD[frontend-app]=f918e74c;         AREA[frontend-app]=6df240fa          # Frontend · Frontend UI
+          SQUAD[tracebloc-website]=f918e74c;    AREA[tracebloc-website]=763b30bf     # Frontend · Website
+          SQUAD[design-system]=f918e74c;        AREA[design-system]=b0ddad7b         # Frontend · Design system
+          SQUAD[docs]=38e2c52d;                 AREA[docs]=aae7e6c3                  # DevEx · Docs
+          SQUAD[documentation]=38e2c52d;        AREA[documentation]=aae7e6c3
+          SQUAD[start-training]=38e2c52d;       AREA[start-training]=aae7e6c3
+          SQUAD[claude-skills]=38e2c52d;        AREA[claude-skills]=f778ef6b
+          SQUAD[.github]=38e2c52d;              AREA[.github]=f778ef6b
+
+          PROJECT_ID="PVT_kwDOCSsgos4BTDWN"
+          SQUAD_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFdds"
+          AREA_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFddw"
+
+          # Paginate through items, find ones missing Squad
+          cursor="null"
+          touched=0
+          while true; do
+            if [ "$cursor" = "null" ]; then after_arg=""; else after_arg=", after: \"$cursor\""; fi
+            page=$(gh api graphql -f query="
+              query {
+                organization(login: \"$ORG\") {
+                  projectV2(number: $PROJECT_NUMBER) {
+                    items(first: 100$after_arg) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        fieldValues(first: 30) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              field { ... on ProjectV2SingleSelectField { name } }
+                              name
+                            }
+                          }
+                        }
+                        content {
+                          ... on Issue { repository { name } }
+                          ... on PullRequest { repository { name } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }")
+
+            echo "$page" | jq -c '.data.organization.projectV2.items.nodes[]' | while read -r node; do
+              has_squad=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Squad") | .name // empty' | head -1)
+              if [ -n "$has_squad" ]; then continue; fi
+              repo=$(echo "$node" | jq -r '.content.repository.name // empty')
+              if [ -z "$repo" ]; then continue; fi
+              squad="${SQUAD[$repo]:-}"; area="${AREA[$repo]:-}"
+              if [ -z "$squad" ]; then continue; fi
+              item_id=$(echo "$node" | jq -r '.id')
+
+              for field_pair in "$SQUAD_FIELD:$squad" "$AREA_FIELD:$area"; do
+                field="${field_pair%:*}"; opt="${field_pair#*:}"
+                gh api graphql -f query="
+                  mutation {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: \"$PROJECT_ID\", itemId: \"$item_id\",
+                      fieldId: \"$field\",
+                      value: { singleSelectOptionId: \"$opt\" }
+                    }) { projectV2Item { id } }
+                  }" > /dev/null
+              done
+              echo "  → classified $repo item ($item_id)"
+              touched=$((touched + 1))
+            done
+
+            hasNext=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+            cursor=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+            if [ "$hasNext" != "true" ]; then break; fi
+          done
+
+          echo "Auto-classifier touched $touched item(s) this run."

--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -1,10 +1,12 @@
-name: Auto-classify kanban items (Squad / Area)
+name: Auto-classify kanban items (Squad / Area / Deploy environment)
 
-# Scans the engineer kanban for items missing Squad classification and sets
-# Squad + Area based on the source repo. Closes the gap where auto-add only
-# sets Status=Backlog without populating downstream fields.
+# Scans the engineer kanban for items missing classification fields and fills them in.
+# - Squad / Area: derived from the source repo
+# - Deploy environment: derived from item type + base branch + merge state
 #
-# Runs every 10 minutes. Idempotent — only touches items where Squad is unset.
+# Closes the gap where auto-add only sets Status=Backlog without populating
+# downstream fields. Runs every 10 minutes. Idempotent — only touches items
+# where the relevant field is unset.
 
 on:
   schedule:
@@ -25,18 +27,18 @@ jobs:
 
           # Repo → Squad option ID + Area option ID
           declare -A SQUAD AREA
-          SQUAD[backend]=acd99fea;              AREA[backend]=43f88b89               # Backend/Platform · Backend API
-          SQUAD[averaging-service]=acd99fea;    AREA[averaging-service]=b5f63849     # Backend/Platform · Averaging
-          SQUAD[client]=acd99fea;               AREA[client]=b3b40fa4                # Backend/Platform · Client (Helm)
-          SQUAD[client-runtime]=acd99fea;       AREA[client-runtime]=beb42207        # Backend/Platform · Runtime
-          SQUAD[tracebloc-client]=e90f32ba;     AREA[tracebloc-client]=beb42207      # Data Science · Runtime
-          SQUAD[tracebloc-py-package]=e90f32ba; AREA[tracebloc-py-package]=ec7cf205  # Data Science · SDK
-          SQUAD[model-zoo]=e90f32ba;            AREA[model-zoo]=0140d45d             # Data Science · Model zoo
-          SQUAD[data-ingestors]=e90f32ba;       AREA[data-ingestors]=4cabb119        # Data Science · Data ingestion
-          SQUAD[frontend-app]=f918e74c;         AREA[frontend-app]=6df240fa          # Frontend · Frontend UI
-          SQUAD[tracebloc-website]=f918e74c;    AREA[tracebloc-website]=763b30bf     # Frontend · Website
-          SQUAD[design-system]=f918e74c;        AREA[design-system]=b0ddad7b         # Frontend · Design system
-          SQUAD[docs]=38e2c52d;                 AREA[docs]=aae7e6c3                  # DevEx · Docs
+          SQUAD[backend]=acd99fea;              AREA[backend]=43f88b89
+          SQUAD[averaging-service]=acd99fea;    AREA[averaging-service]=b5f63849
+          SQUAD[client]=acd99fea;               AREA[client]=b3b40fa4
+          SQUAD[client-runtime]=acd99fea;       AREA[client-runtime]=beb42207
+          SQUAD[tracebloc-client]=e90f32ba;     AREA[tracebloc-client]=beb42207
+          SQUAD[tracebloc-py-package]=e90f32ba; AREA[tracebloc-py-package]=ec7cf205
+          SQUAD[model-zoo]=e90f32ba;            AREA[model-zoo]=0140d45d
+          SQUAD[data-ingestors]=e90f32ba;       AREA[data-ingestors]=4cabb119
+          SQUAD[frontend-app]=f918e74c;         AREA[frontend-app]=6df240fa
+          SQUAD[tracebloc-website]=f918e74c;    AREA[tracebloc-website]=763b30bf
+          SQUAD[design-system]=f918e74c;        AREA[design-system]=b0ddad7b
+          SQUAD[docs]=38e2c52d;                 AREA[docs]=aae7e6c3
           SQUAD[documentation]=38e2c52d;        AREA[documentation]=aae7e6c3
           SQUAD[start-training]=38e2c52d;       AREA[start-training]=aae7e6c3
           SQUAD[claude-skills]=38e2c52d;        AREA[claude-skills]=f778ef6b
@@ -45,10 +47,29 @@ jobs:
           PROJECT_ID="PVT_kwDOCSsgos4BTDWN"
           SQUAD_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFdds"
           AREA_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFddw"
+          DEPLOY_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFak0"
 
-          # Paginate through items, find ones missing Squad
+          # Deploy env option IDs
+          DEPLOY_NONE="14e41520"
+          DEPLOY_DEV="2bd56845"
+          DEPLOY_STAGING="cadea71b"
+          DEPLOY_PROD="4c9dd784"
+
+          set_field() {
+            gh api graphql -f query="
+              mutation {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: \"$PROJECT_ID\", itemId: \"$1\",
+                  fieldId: \"$2\",
+                  value: { singleSelectOptionId: \"$3\" }
+                }) { projectV2Item { id } }
+              }" > /dev/null
+          }
+
+          # Paginate through items
           cursor="null"
-          touched=0
+          touched_squad=0
+          touched_deploy=0
           while true; do
             if [ "$cursor" = "null" ]; then after_arg=""; else after_arg=", after: \"$cursor\""; fi
             page=$(gh api graphql -f query="
@@ -69,7 +90,12 @@ jobs:
                         }
                         content {
                           ... on Issue { repository { name } }
-                          ... on PullRequest { repository { name } }
+                          ... on PullRequest {
+                            repository { name }
+                            merged
+                            state
+                            baseRefName
+                          }
                         }
                       }
                     }
@@ -78,27 +104,52 @@ jobs:
               }")
 
             echo "$page" | jq -c '.data.organization.projectV2.items.nodes[]' | while read -r node; do
-              has_squad=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Squad") | .name // empty' | head -1)
-              if [ -n "$has_squad" ]; then continue; fi
+              item_id=$(echo "$node" | jq -r '.id')
               repo=$(echo "$node" | jq -r '.content.repository.name // empty')
               if [ -z "$repo" ]; then continue; fi
-              squad="${SQUAD[$repo]:-}"; area="${AREA[$repo]:-}"
-              if [ -z "$squad" ]; then continue; fi
-              item_id=$(echo "$node" | jq -r '.id')
 
-              for field_pair in "$SQUAD_FIELD:$squad" "$AREA_FIELD:$area"; do
-                field="${field_pair%:*}"; opt="${field_pair#*:}"
-                gh api graphql -f query="
-                  mutation {
-                    updateProjectV2ItemFieldValue(input: {
-                      projectId: \"$PROJECT_ID\", itemId: \"$item_id\",
-                      fieldId: \"$field\",
-                      value: { singleSelectOptionId: \"$opt\" }
-                    }) { projectV2Item { id } }
-                  }" > /dev/null
-              done
-              echo "  → classified $repo item ($item_id)"
-              touched=$((touched + 1))
+              # ─── Squad / Area: set if unset ───
+              has_squad=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Squad") | .name // empty' | head -1)
+              if [ -z "$has_squad" ]; then
+                squad="${SQUAD[$repo]:-}"; area="${AREA[$repo]:-}"
+                if [ -n "$squad" ]; then
+                  set_field "$item_id" "$SQUAD_FIELD" "$squad"
+                  set_field "$item_id" "$AREA_FIELD" "$area"
+                  echo "  → Squad/Area: $repo item ($item_id)"
+                  touched_squad=$((touched_squad + 1))
+                fi
+              fi
+
+              # ─── Deploy environment: set if unset ───
+              has_deploy=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Deploy environment") | .name // empty' | head -1)
+              if [ -z "$has_deploy" ]; then
+                # Determine target based on item type / state / base
+                merged=$(echo "$node" | jq -r '.content.merged // empty')
+                state=$(echo "$node" | jq -r '.content.state // empty')
+                base=$(echo "$node" | jq -r '.content.baseRefName // empty')
+
+                target=""
+                if [ -z "$merged" ] && [ "$state" = "" ]; then
+                  # Issue (no merged field) — always none
+                  target="$DEPLOY_NONE"
+                elif [ "$state" = "OPEN" ]; then
+                  target="$DEPLOY_NONE"
+                elif [ "$state" = "CLOSED" ] && [ "$merged" != "true" ]; then
+                  target="$DEPLOY_NONE"
+                elif [ "$merged" = "true" ]; then
+                  case "$base" in
+                    develop)     target="$DEPLOY_DEV" ;;
+                    staging)     target="$DEPLOY_STAGING" ;;
+                    main|master) target="$DEPLOY_PROD" ;;
+                  esac
+                fi
+
+                if [ -n "$target" ]; then
+                  set_field "$item_id" "$DEPLOY_FIELD" "$target"
+                  echo "  → Deploy env: $repo item ($item_id)"
+                  touched_deploy=$((touched_deploy + 1))
+                fi
+              fi
             done
 
             hasNext=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
@@ -106,4 +157,5 @@ jobs:
             if [ "$hasNext" != "true" ]; then break; fi
           done
 
-          echo "Auto-classifier touched $touched item(s) this run."
+          echo ""
+          echo "Run summary: Squad/Area touched=$touched_squad · Deploy env touched=$touched_deploy"


### PR DESCRIPTION
Adds a single workflow that runs every 10 minutes and fills missing classification fields on the engineer kanban — based on the source repo and item type/state.

## What it sets

| Field | Source of truth | When |
|---|---|---|
| **Squad** | Repo → Squad mapping (baked into workflow) | Item missing Squad |
| **Area** | Repo → Area mapping | Item missing Area |
| **Deploy environment** | Item type + base branch + merge state | Item missing Deploy env |

## Deploy env rules

| Item shape | Deploy env |
|---|---|
| Issue | `none` |
| Open PR | `none` |
| Closed-not-merged PR | `none` |
| Merged PR to `develop` | `dev` |
| Merged PR to `staging` | `staging` |
| Merged PR to `main`/`master` | `prod` |

## Why

Auto-add and the per-event workflows leave gaps:
- New issues land in Backlog with no Squad/Area/Deploy env → invisible to most curated views
- Items merged before a per-repo caller workflow was deployed kept blank fields
- Closed-not-merged PRs had no obvious Deploy env signal

The cron passes are idempotent (only touches unset fields), low cost, and survive any per-event workflow drift.

## Activation

Workflow runs on the project automatically once merged. Manual trigger via `workflow_dispatch` for ad-hoc backfills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)