### PR TITLE
chore: promote kanban-closure-router to main

### DIFF
--- a/.github/workflows/kanban-closure-router.yml
+++ b/.github/workflows/kanban-closure-router.yml
@@ -1,0 +1,128 @@
+name: Route kanban Status on closure
+
+# Reusable workflow. Called on PR closed + issue closed events.
+# Sets the correct Status based on what actually happened:
+#   - PR merged                      → Done
+#   - PR closed without merging      → Cancelled
+#   - Issue closed as completed      → Done
+#   - Issue closed as not_planned    → Cancelled
+#   - Issue closed (no state_reason) → Cancelled (default to abandoned)
+
+on:
+  workflow_call:
+    inputs:
+      project-number:
+        type: number
+        default: 2
+      org:
+        type: string
+        default: tracebloc
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine target Status
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          ISSUE_REASON: ${{ github.event.issue.state_reason }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if [ "$PR_MERGED" = "true" ]; then
+              echo "status=Done"      >> "$GITHUB_OUTPUT"
+            else
+              echo "status=Cancelled" >> "$GITHUB_OUTPUT"
+            fi
+          elif [ "$EVENT_NAME" = "issues" ]; then
+            if [ "$ISSUE_REASON" = "completed" ]; then
+              echo "status=Done"      >> "$GITHUB_OUTPUT"
+            else
+              echo "status=Cancelled" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Unexpected event '$EVENT_NAME' — skipping"
+            echo "status=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Routing decision: status=$(grep status= "$GITHUB_OUTPUT" | tail -1 | cut -d= -f2)"
+
+      - name: Update Status on the kanban
+        if: steps.target.outputs.status != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_KANBAN_TOKEN }}
+          ORG: ${{ inputs.org }}
+          PROJECT_NUMBER: ${{ inputs.project-number }}
+          STATUS_NAME: ${{ steps.target.outputs.status }}
+          NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+          REPO_FULL: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          REPO_NAME="${REPO_FULL#*/}"
+
+          # Look up project ID + Status field/option IDs
+          PROJ=$(gh api graphql -f query='
+            query($org: String!, $num: Int!) {
+              organization(login: $org) {
+                projectV2(number: $num) {
+                  id
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2SingleSelectField { id name options { id name } }
+                    }
+                  }
+                }
+              }
+            }' -F org="$ORG" -F num="$PROJECT_NUMBER")
+
+          PROJECT_ID=$(echo "$PROJ" | jq -r '.data.organization.projectV2.id')
+          STATUS_FIELD=$(echo "$PROJ" | jq -r '.data.organization.projectV2.fields.nodes[]
+            | select(.name=="Status") | .id')
+          STATUS_OPT=$(echo "$PROJ" | jq -r --arg s "$STATUS_NAME" '.data.organization.projectV2.fields.nodes[]
+            | select(.name=="Status") | .options[] | select(.name==$s) | .id')
+
+          if [ -z "$STATUS_OPT" ] || [ "$STATUS_OPT" = "null" ]; then
+            echo "Could not resolve Status option '$STATUS_NAME' — aborting"
+            exit 1
+          fi
+
+          # Find item ID for this PR or issue
+          if [ "$IS_PR" = "true" ]; then
+            FIELD_QUERY='pullRequest(number: $num) { projectItems(first: 10) { nodes { id project { number } } } }'
+          else
+            FIELD_QUERY='issue(number: $num) { projectItems(first: 10) { nodes { id project { number } } } }'
+          fi
+
+          # Retry briefly to let auto-add fire if needed
+          for i in 1 2 3 4 5; do
+            RESP=$(gh api graphql -f query="
+              query(\$org: String!, \$repo: String!, \$num: Int!) {
+                repository(owner: \$org, name: \$repo) {
+                  $FIELD_QUERY
+                }
+              }" -F org="$ORG" -F repo="$REPO_NAME" -F num="$NUMBER" 2>/dev/null) || RESP='{}'
+
+            ITEM_ID=$(echo "$RESP" | jq -r --arg n "$PROJECT_NUMBER" '
+              ([.. | objects | select(has("projectItems"))] | first).projectItems.nodes[]?
+              | select(.project.number == ($n | tonumber)) | .id' | head -1)
+            if [ -n "$ITEM_ID" ] && [ "$ITEM_ID" != "null" ]; then break; fi
+            echo "Item not yet on project, retry $i/5..."
+            sleep 5
+          done
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "Item #$NUMBER not on project after 5 retries — skipping."
+            exit 0
+          fi
+
+          gh api graphql -f query='
+            mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $p, itemId: $i, fieldId: $f,
+                value: {singleSelectOptionId: $o}
+              }) { projectV2Item { id } }
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$STATUS_OPT" > /dev/null
+
+          echo "→ #$NUMBER → Status=$STATUS_NAME"


### PR DESCRIPTION
Promotes the new closure-router reusable workflow to `main` so callers can reference it as `@main`.