### PR TITLE
fix(ci): rename 'In review' → 'Code review' in set-pr-status workflow

### DIFF
--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -25,7 +25,7 @@ jobs:
           if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
             echo "status_name=In progress" >> "$GITHUB_OUTPUT"
           else
-            echo "status_name=In review" >> "$GITHUB_OUTPUT"
+            echo "status_name=Code review" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Update PR Status on project


### PR DESCRIPTION
Status options renamed today for clarity:
- `In review` → `Code review`
- `Validation` → `Functional review`

The `set-pr-status` reusable workflow looks up the Status option by name when setting it on PR open. Updating the hardcoded reference to match the new name.

`advance-deploy-env`, `kanban-closure-router`, and the cron auto-classifier reference `Done` / `Cancelled` (unchanged) — no update needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)