### PR TITLE
ci: add WIP-limit-check caller workflow

### DIFF
--- a/.github/workflows/wip-limit-caller.yml
+++ b/.github/workflows/wip-limit-caller.yml
@@ -1,0 +1,10 @@
+name: WIP limit check
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  check:
+    uses: tracebloc/.github/.github/workflows/wip-limit-check.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a 9-line caller workflow that triggers the org-wide reusable workflow [`wip-limit-check.yml`](https://github.com/tracebloc/.github/blob/main/.github/workflows/wip-limit-check.yml) on PR open / ready_for_review.

## Behavior

When a PR opens:
- Reads the engineer kanban's `Code review` column
- If count > 8 (the WIP limit), posts a comment on the new PR with the list of open PRs already in queue
- **Does not block the PR** — informational nudge only

## Why

Surfaces team kanban discipline at decision time: pull from review before opening new work. Same shape as the other `tracebloc/.github` reusable workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)