### PR TITLE
fix: WIP-limit-check renders real URLs and excludes drafts

### DIFF
--- a/.github/workflows/wip-limit-check.yml
+++ b/.github/workflows/wip-limit-check.yml
@@ -79,9 +79,9 @@ jobs:
             [ "$hasNext" != "true" ] && break
           done
 
-          # Filter to PRs in target Status, currently OPEN
+          # Filter to PRs in target Status, currently OPEN, not draft
           jq -c --arg s "$STATUS_NAME" '
-            select(.content.state == "OPEN" and (.content.merged // null) == null
+            select(.content.state == "OPEN" and .content.isDraft == false
                    and (.fieldValues.nodes[]? | select(.field.name == "Status") | .name) == $s)
           ' /tmp/items.txt > /tmp/inreview.txt
 
@@ -102,10 +102,10 @@ jobs:
             echo ""
             echo "Open PRs currently in Code review (oldest first):"
             echo ""
-            jq -r --arg me "$PR_AUTHOR" --arg pr "$PR_NUMBER" '
+            jq -r --arg me "$PR_AUTHOR" --arg pr "$PR_NUMBER" --arg org "$ORG" '
               .content as $c
               | select($c.number != ($pr | tonumber))
-              | "- [\($c.repository.name)#\($c.number)](\($c.repository.name)#\($c.number)) — \($c.title) · author: @\($c.author.login) · " +
+              | "- [\($c.repository.name)#\($c.number)](https://github.com/\($org)/\($c.repository.name)/pull/\($c.number)) — \($c.title) · author: @\($c.author.login) · " +
                 ((.content.reviewRequests.nodes | map(.requestedReviewer.login) | map(select(.)) | join(", @")) as $rev
                  | if ($rev | length) > 0 then "reviewer: @\($rev)" else "no reviewer assigned" end)
             ' /tmp/inreview.txt | sort | head -10


### PR DESCRIPTION
Follow-up to #22.

Closes #26.

## Summary

- **Broken markdown link in comment.** The list jq emitted `[repo#N](repo#N)` — the link target wasn't a URL, so the rendered comment had broken links. Now passes `--arg org "$ORG"` into jq and emits `https://github.com/<org>/<repo>/pull/<N>`.
- **Drafts no longer count toward the WIP cap.** `isDraft` was queried in GraphQL but never filtered. Added `.content.isDraft == false` to the queue filter (replacing the no-op `.content.merged // null` clause — `merged` isn't selected in the query, so it was always null and did nothing).

## Test plan

- [ ] Wire one caller repo to the updated workflow at this branch (e.g. `uses: tracebloc/.github/.github/workflows/wip-limit-check.yml@ci/wip-limit-check-fixups`) and open a PR while the kanban Code-review column is over the limit. Expect: comment with clickable links, drafts excluded from the count.
- [ ] Re-test with the column under the limit — workflow should exit silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a GitHub Actions workflow that only affects how the review-queue count and comment links are generated; no production code or data paths impacted.
> 
> **Overview**
> Updates the `wip-limit-check` reusable workflow to **exclude draft PRs** from the Code Review WIP count by filtering on `content.isDraft == false`.
> 
> Fixes the over-limit comment’s PR list to emit **fully qualified GitHub URLs** (using the configured `org`) instead of broken `[repo#N](repo#N)` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00978e1dd9d825c4fe2cbbfe17b0ea7a3b3c06db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->