### PR TITLE
release: promote develop to main (WIP-limit-check fix + cron auto-classifier)

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -103,7 +103,7 @@ jobs:
                 }
               }")
 
-            echo "$page" | jq -c '.data.organization.projectV2.items.nodes[]' | while read -r node; do
+            while read -r node; do
               item_id=$(echo "$node" | jq -r '.id')
               repo=$(echo "$node" | jq -r '.content.repository.name // empty')
               if [ -z "$repo" ]; then continue; fi
@@ -150,7 +150,7 @@ jobs:
                   touched_deploy=$((touched_deploy + 1))
                 fi
               fi
-            done
+            done < <(echo "$page" | jq -c '.data.organization.projectV2.items.nodes[]')
 
             hasNext=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
             cursor=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')

--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -1,0 +1,161 @@
+name: Auto-classify kanban items (Squad / Area / Deploy environment)
+
+# Scans the engineer kanban for items missing classification fields and fills them in.
+# - Squad / Area: derived from the source repo
+# - Deploy environment: derived from item type + base branch + merge state
+#
+# Closes the gap where auto-add only sets Status=Backlog without populating
+# downstream fields. Runs every 10 minutes. Idempotent — only touches items
+# where the relevant field is unset.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find + classify unclassified items
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_KANBAN_TOKEN }}
+          PROJECT_NUMBER: 2
+          ORG: tracebloc
+        run: |
+          set -euo pipefail
+
+          # Repo → Squad option ID + Area option ID
+          declare -A SQUAD AREA
+          SQUAD[backend]=acd99fea;              AREA[backend]=43f88b89
+          SQUAD[averaging-service]=acd99fea;    AREA[averaging-service]=b5f63849
+          SQUAD[client]=acd99fea;               AREA[client]=b3b40fa4
+          SQUAD[client-runtime]=acd99fea;       AREA[client-runtime]=beb42207
+          SQUAD[tracebloc-client]=e90f32ba;     AREA[tracebloc-client]=beb42207
+          SQUAD[tracebloc-py-package]=e90f32ba; AREA[tracebloc-py-package]=ec7cf205
+          SQUAD[model-zoo]=e90f32ba;            AREA[model-zoo]=0140d45d
+          SQUAD[data-ingestors]=e90f32ba;       AREA[data-ingestors]=4cabb119
+          SQUAD[frontend-app]=f918e74c;         AREA[frontend-app]=6df240fa
+          SQUAD[tracebloc-website]=f918e74c;    AREA[tracebloc-website]=763b30bf
+          SQUAD[design-system]=f918e74c;        AREA[design-system]=b0ddad7b
+          SQUAD[docs]=38e2c52d;                 AREA[docs]=aae7e6c3
+          SQUAD[documentation]=38e2c52d;        AREA[documentation]=aae7e6c3
+          SQUAD[start-training]=38e2c52d;       AREA[start-training]=aae7e6c3
+          SQUAD[claude-skills]=38e2c52d;        AREA[claude-skills]=f778ef6b
+          SQUAD[.github]=38e2c52d;              AREA[.github]=f778ef6b
+
+          PROJECT_ID="PVT_kwDOCSsgos4BTDWN"
+          SQUAD_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFdds"
+          AREA_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFddw"
+          DEPLOY_FIELD="PVTSSF_lADOCSsgos4BTDWNzhRFak0"
+
+          # Deploy env option IDs
+          DEPLOY_NONE="14e41520"
+          DEPLOY_DEV="2bd56845"
+          DEPLOY_STAGING="cadea71b"
+          DEPLOY_PROD="4c9dd784"
+
+          set_field() {
+            gh api graphql -f query="
+              mutation {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: \"$PROJECT_ID\", itemId: \"$1\",
+                  fieldId: \"$2\",
+                  value: { singleSelectOptionId: \"$3\" }
+                }) { projectV2Item { id } }
+              }" > /dev/null
+          }
+
+          # Paginate through items
+          cursor="null"
+          touched_squad=0
+          touched_deploy=0
+          while true; do
+            if [ "$cursor" = "null" ]; then after_arg=""; else after_arg=", after: \"$cursor\""; fi
+            page=$(gh api graphql -f query="
+              query {
+                organization(login: \"$ORG\") {
+                  projectV2(number: $PROJECT_NUMBER) {
+                    items(first: 100$after_arg) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        fieldValues(first: 30) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              field { ... on ProjectV2SingleSelectField { name } }
+                              name
+                            }
+                          }
+                        }
+                        content {
+                          ... on Issue { repository { name } }
+                          ... on PullRequest {
+                            repository { name }
+                            merged
+                            state
+                            baseRefName
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }")
+
+            echo "$page" | jq -c '.data.organization.projectV2.items.nodes[]' | while read -r node; do
+              item_id=$(echo "$node" | jq -r '.id')
+              repo=$(echo "$node" | jq -r '.content.repository.name // empty')
+              if [ -z "$repo" ]; then continue; fi
+
+              # ─── Squad / Area: set if unset ───
+              has_squad=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Squad") | .name // empty' | head -1)
+              if [ -z "$has_squad" ]; then
+                squad="${SQUAD[$repo]:-}"; area="${AREA[$repo]:-}"
+                if [ -n "$squad" ]; then
+                  set_field "$item_id" "$SQUAD_FIELD" "$squad"
+                  set_field "$item_id" "$AREA_FIELD" "$area"
+                  echo "  → Squad/Area: $repo item ($item_id)"
+                  touched_squad=$((touched_squad + 1))
+                fi
+              fi
+
+              # ─── Deploy environment: set if unset ───
+              has_deploy=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Deploy environment") | .name // empty' | head -1)
+              if [ -z "$has_deploy" ]; then
+                # Determine target based on item type / state / base
+                merged=$(echo "$node" | jq -r '.content.merged // empty')
+                state=$(echo "$node" | jq -r '.content.state // empty')
+                base=$(echo "$node" | jq -r '.content.baseRefName // empty')
+
+                target=""
+                if [ -z "$merged" ] && [ "$state" = "" ]; then
+                  # Issue (no merged field) — always none
+                  target="$DEPLOY_NONE"
+                elif [ "$state" = "OPEN" ]; then
+                  target="$DEPLOY_NONE"
+                elif [ "$state" = "CLOSED" ] && [ "$merged" != "true" ]; then
+                  target="$DEPLOY_NONE"
+                elif [ "$merged" = "true" ]; then
+                  case "$base" in
+                    develop)     target="$DEPLOY_DEV" ;;
+                    staging)     target="$DEPLOY_STAGING" ;;
+                    main|master) target="$DEPLOY_PROD" ;;
+                  esac
+                fi
+
+                if [ -n "$target" ]; then
+                  set_field "$item_id" "$DEPLOY_FIELD" "$target"
+                  echo "  → Deploy env: $repo item ($item_id)"
+                  touched_deploy=$((touched_deploy + 1))
+                fi
+              fi
+            done
+
+            hasNext=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.hasNextPage')
+            cursor=$(echo "$page" | jq -r '.data.organization.projectV2.items.pageInfo.endCursor')
+            if [ "$hasNext" != "true" ]; then break; fi
+          done
+
+          echo ""
+          echo "Run summary: Squad/Area touched=$touched_squad · Deploy env touched=$touched_deploy"

--- a/.github/workflows/wip-limit-check.yml
+++ b/.github/workflows/wip-limit-check.yml
@@ -79,9 +79,9 @@ jobs:
             [ "$hasNext" != "true" ] && break
           done
 
-          # Filter to PRs in target Status, currently OPEN
+          # Filter to PRs in target Status, currently OPEN, not draft
           jq -c --arg s "$STATUS_NAME" '
-            select(.content.state == "OPEN" and (.content.merged // null) == null
+            select(.content.state == "OPEN" and .content.isDraft == false
                    and (.fieldValues.nodes[]? | select(.field.name == "Status") | .name) == $s)
           ' /tmp/items.txt > /tmp/inreview.txt
 
@@ -102,10 +102,10 @@ jobs:
             echo ""
             echo "Open PRs currently in Code review (oldest first):"
             echo ""
-            jq -r --arg me "$PR_AUTHOR" --arg pr "$PR_NUMBER" '
+            jq -r --arg me "$PR_AUTHOR" --arg pr "$PR_NUMBER" --arg org "$ORG" '
               .content as $c
               | select($c.number != ($pr | tonumber))
-              | "- [\($c.repository.name)#\($c.number)](\($c.repository.name)#\($c.number)) — \($c.title) · author: @\($c.author.login) · " +
+              | "- [\($c.repository.name)#\($c.number)](https://github.com/\($org)/\($c.repository.name)/pull/\($c.number)) — \($c.title) · author: @\($c.author.login) · " +
                 ((.content.reviewRequests.nodes | map(.requestedReviewer.login) | map(select(.)) | join(", @")) as $rev
                  | if ($rev | length) > 0 then "reviewer: @\($rev)" else "no reviewer assigned" end)
             ' /tmp/inreview.txt | sort | head -10


### PR DESCRIPTION
Promotes the current state of \`develop\` to \`main\` so wired callers pick up the recent changes.

## What ships

- **[#27](https://github.com/tracebloc/.github/pull/27) — fix: WIP-limit-check renders real URLs and excludes drafts** (closes [#26](https://github.com/tracebloc/.github/issues/26)). Caller workflows (currently \`tracebloc-py-package\`) pin \`@main\`, so this is the cut that makes the fix live.
- **[#16](https://github.com/tracebloc/.github/pull/16) — ci: add cron auto-classifier (Squad / Area / Deploy environment)**.

## Compare

\`\`\`
gh api repos/tracebloc/.github/compare/main...develop
ahead: 2, behind: 8
\`\`\`

(\`behind: 8\` is from main-side commits that haven't been backported to develop — out of scope for this promotion. They can be reconciled separately if needed.)

## Test plan

- [ ] After merge, open any PR in \`tracebloc-py-package\` (or any other repo whose caller pins \`@main\`); with the kanban Code review queue currently at 31, the workflow should post a nudge comment with **clickable URLs** and **drafts excluded** from the list.
- [ ] Confirm the cron auto-classifier from #16 fires on schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces/changes GitHub automation that writes to Project V2 fields and posts PR comments; misconfiguration of option IDs or query assumptions could incorrectly classify items or spam comments.
> 
> **Overview**
> Adds a new scheduled GitHub Actions workflow, `auto-classify.yml`, that scans the org Project V2 kanban and **backfills missing `Squad`, `Area`, and `Deploy environment` fields** based on repository name and PR merge/base-branch state (idempotent; only updates unset fields).
> 
> Updates `wip-limit-check.yml` to **exclude draft PRs** from the “Code review” queue count and to render the comment’s PR list with **fully qualified GitHub URLs** instead of repo-relative links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c6f972d7df1dad9a0f6c1a453fea4e706f80b7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->