### PR TITLE
fix(wip-limit-check): drop permissions block — caused startup_failure

### DIFF
--- a/.github/workflows/wip-limit-check.yml
+++ b/.github/workflows/wip-limit-check.yml
@@ -23,8 +23,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - name: Count items in Code review and comment if over limit
         env:


### PR DESCRIPTION
The reusable workflow declared `permissions: pull-requests: write` on its job. Callers (e.g. \`tracebloc-py-package\`) don't grant that, and GitHub forbids called workflows from elevating \`GITHUB_TOKEN\` scope, so the workflow short-circuits to \`startup_failure\` before any step runs.

The block is also unnecessary: this workflow doesn't use \`GITHUB_TOKEN\` at all — \`gh pr comment\` runs under \`secrets.PROJECTS_KANBAN_TOKEN\` (a PAT). Removing it restores startup parity with the other reusable workflows in this repo (\`set-pr-status\`, \`add-to-kanban\`, \`auto-classify\`, \`kanban-closure-router\`), none of which declare a permissions block.

## Reproducer

[tracebloc/tracebloc-py-package#117](https://github.com/tracebloc/tracebloc-py-package/pull/117) → run [25170342114](https://github.com/tracebloc/tracebloc-py-package/actions/runs/25170342114) → `conclusion: startup_failure`, 0 jobs spawned.

## Test plan

- [ ] Merge to develop, promote develop → main.
- [ ] Re-trigger PR #117 (close + reopen, or push a no-op commit). Workflow should reach the run step and either post a comment (queue > limit) or exit silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unnecessary `permissions` block that was preventing the reusable workflow from starting when callers don’t grant elevated `GITHUB_TOKEN` scopes.
> 
> **Overview**
> Fixes the reusable `wip-limit-check` workflow failing with `startup_failure` by removing the job-level `permissions: pull-requests: write` declaration.
> 
> This ensures the workflow runs under the existing PAT (`secrets.PROJECTS_KANBAN_TOKEN`) without attempting to elevate `GITHUB_TOKEN` permissions in called workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7980d6c398dbb0bf5af69c0108267aecee7d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->