### PR TITLE
fix(profile): point install snippets to canonical i.sh / i.ps1 URLs

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,13 +7,13 @@
 **Mac / Linux**
 
 ```bash
-bash <(curl -fsSL https://tracebloc.io/install.sh)
+bash <(curl -fsSL https://tracebloc.io/i.sh)
 ```
 
 **Windows**
 
 ```powershell
-irm https://tracebloc.io/install.ps1 | iex
+irm https://tracebloc.io/i.ps1 | iex
 ```
 
 


### PR DESCRIPTION
## Summary
- The Mac/Linux and Windows install snippets on the org profile linked to `install.sh` / `install.ps1`, which both return **404**.
- Switched them to the canonical `i.sh` / `i.ps1` URLs, per the [docs setup guide](https://docs.tracebloc.io/environment-setup/setup-guide). Both return 200.

Closes #40

## Test plan
- [x] `curl -sI https://tracebloc.io/i.sh` → 200
- [x] `curl -sI https://tracebloc.io/i.ps1` → 200
- [ ] After merge, view https://github.com/tracebloc and confirm the rendered snippets show the new URLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating install command URLs; no code paths or runtime behavior are affected.
> 
> **Overview**
> Updates the org profile `README.md` install snippets to use the canonical `https://tracebloc.io/i.sh` (Mac/Linux) and `https://tracebloc.io/i.ps1` (Windows) URLs instead of the previous `install.*` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe79d94738194d72b003d391e0cd10651fa4c592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->