### PR TITLE
fix(closure-router): add ORG + REPO_FULL to Determine step env

### DIFF
--- a/.github/workflows/kanban-closure-router.yml
+++ b/.github/workflows/kanban-closure-router.yml
@@ -39,6 +39,12 @@ jobs:
           PR_MERGED: ${{ github.event.pull_request.merged }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           ISSUE_REASON: ${{ github.event.issue.state_reason }}
+          # ORG + REPO_FULL needed by the "issue closed as completed" branch when
+          # it does the closing-PR-base lookup. Without these, `set -u` aborted
+          # the script before any status= output was written, leaving the
+          # built-in "Item closed" project workflow to set Status=Cancelled.
+          ORG: ${{ inputs.org }}
+          REPO_FULL: ${{ github.repository }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "pull_request" ]; then


### PR DESCRIPTION
## Summary

Closure-router has been silently failing on **every issue closed-as-completed** since #38 landed. The Determine step references `$REPO_FULL` (via `REPO_NAME`) and `$ORG` inside the closing-PR-base lookup, but neither was declared in that step's env block. With `set -u`, the script aborted on line 17 with `REPO_FULL: unbound variable` before writing any `status=` output — which left the built-in **"Item closed"** project workflow to set `Status=Cancelled` by default.

## Impact on the kanban

~37 completed-state issues are currently sitting in `Cancelled` instead of `Prod` since 2026-05-06. Will backfill via GraphQL after this lands.

## Fix

Declare `ORG` + `REPO_FULL` in the Determine step's env block, matching what the Update step already has. After this, the script correctly hits the `case "$CLOSING_PR_BASE"` branch and emits `status=Prod` (for manual close with no linked PR) or mirrors the closing PR's base.

## Why this took a week to spot

Two compounding factors:
1. The job conclusion shows `failure`, but failures on `issues` events are easy to miss — they don't gate merges, don't appear on PRs, and only show up in the Actions tab.
2. GitHub's built-in "Item closed" project workflow runs in parallel and sets `Status=Cancelled` as a fallback. So items still moved *somewhere* — just to the wrong column. Symptom looked like "router silently misclassifies" instead of "router crashes".

## Follow-up

After this is on `main`, recommend disabling the built-in "Item closed" and "Pull request merged" project workflows via the UI (no API for it) so our custom router has exclusive control of Status transitions.

## Test plan

- [ ] After merge to main, close a test issue as `completed` → verify Status moves to `Prod`
- [ ] Close a test issue as `not_planned` → verify Status moves to `Cancelled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
