### PR TITLE
fix(auto-classify): sync Deploy env from Status instead of "set if unset"

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -1,12 +1,13 @@
 name: Auto-classify kanban items (Squad / Area / Deploy environment)
 
-# Scans the engineer kanban for items missing classification fields and fills them in.
-# - Squad / Area: derived from the source repo
-# - Deploy environment: derived from item type + base branch + merge state
+# Scans the engineer kanban every 10 min and reconciles classification fields:
+# - Squad / Area: derived from the source repo. Set only if unset (idempotent).
+# - Deploy environment: derived from Status. Overwrites if it doesn't match,
+#   so Deploy env always tracks the kanban column. Status is source of truth.
 #
-# Closes the gap where auto-add only sets Status=Backlog without populating
-# downstream fields. Runs every 10 minutes. Idempotent — only touches items
-# where the relevant field is unset.
+# Why Deploy is now sync (not "set if unset"): advance-deploy-env updates it on
+# pushes, but closure-router (issue close), manual drag-and-drop, and one-off
+# backfills only touch Status — leaving Deploy stale. This cron re-syncs.
 
 on:
   schedule:
@@ -120,35 +121,33 @@ jobs:
                 fi
               fi
 
-              # ─── Deploy environment: set if unset ───
-              has_deploy=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Deploy environment") | .name // empty' | head -1)
-              if [ -z "$has_deploy" ]; then
-                # Determine target based on item type / state / base
-                merged=$(echo "$node" | jq -r '.content.merged // empty')
-                state=$(echo "$node" | jq -r '.content.state // empty')
-                base=$(echo "$node" | jq -r '.content.baseRefName // empty')
+              # ─── Deploy environment: derive from Status ───
+              # Status is the source of truth. Deploy environment tracks where the
+              # item is currently running, which is fully determined by the kanban
+              # column it's in. The advance-deploy-env workflow keeps these aligned
+              # on pushes, but other paths (closure-router setting Status on issue
+              # close, manual drag-and-drop on the board, my backfills) only touch
+              # Status — leaving Deploy env stale. This cron re-syncs.
+              status=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Status") | .name // empty' | head -1)
+              current_deploy=$(echo "$node" | jq -r '.fieldValues.nodes[]? | select(.field.name == "Deploy environment") | .name // empty' | head -1)
 
-                target=""
-                if [ -z "$merged" ] && [ "$state" = "" ]; then
-                  # Issue (no merged field) — always none
-                  target="$DEPLOY_NONE"
-                elif [ "$state" = "OPEN" ]; then
-                  target="$DEPLOY_NONE"
-                elif [ "$state" = "CLOSED" ] && [ "$merged" != "true" ]; then
-                  target="$DEPLOY_NONE"
-                elif [ "$merged" = "true" ]; then
-                  case "$base" in
-                    develop)     target="$DEPLOY_DEV" ;;
-                    staging)     target="$DEPLOY_STAGING" ;;
-                    main|master) target="$DEPLOY_PROD" ;;
-                  esac
-                fi
+              target=""
+              target_name=""
+              case "$status" in
+                "Backlog"|"Ready"|"In progress"|"Code review"|"Cancelled"|"")
+                  target="$DEPLOY_NONE"; target_name="none" ;;
+                "FR on dev"|"Ready for staging")
+                  target="$DEPLOY_DEV"; target_name="dev" ;;
+                "FR on staging"|"Ready for prod")
+                  target="$DEPLOY_STAGING"; target_name="staging" ;;
+                "Prod")
+                  target="$DEPLOY_PROD"; target_name="prod" ;;
+              esac
 
-                if [ -n "$target" ]; then
-                  set_field "$item_id" "$DEPLOY_FIELD" "$target"
-                  echo "  → Deploy env: $repo item ($item_id)"
-                  touched_deploy=$((touched_deploy + 1))
-                fi
+              if [ -n "$target" ] && [ "$current_deploy" != "$target_name" ]; then
+                set_field "$item_id" "$DEPLOY_FIELD" "$target"
+                echo "  → Deploy env: $repo item ($item_id) → $target_name (was: ${current_deploy:-unset})"
+                touched_deploy=$((touched_deploy + 1))
               fi
             done < <(echo "$page" | jq -c '.data.organization.projectV2.items.nodes[]')
 


### PR DESCRIPTION
## Summary

The "Deployment environment" board view was showing hundreds of `Prod` cards in the `dev` and `staging` columns — because Status and Deploy environment had silently drifted apart.

Audit on 2026-05-14 found **311 of 449 `Prod` items** (69%) with a wrong `Deploy environment` value. Just synced them via GraphQL — but this PR closes the leak so it doesn't recur.

## Root cause

`advance-deploy-env` updates both fields atomically on push events, but several other paths only touch `Status`:

- `kanban-closure-router` on issue close → sets Status, never touches Deploy
- Manual drag-and-drop on the board → updates Status only
- One-off backfills → updated Status only

Auto-classify was a candidate to reconcile, but its Deploy section was conservative: only fill if unset, never overwrite. So drift accumulated.

## Fix

Make Deploy environment a *derived* field — always sync from Status:

| Status | Deploy environment |
|---|---|
| Backlog / Ready / In progress / Code review / Cancelled | `none` |
| FR on dev / Ready for staging | `dev` |
| FR on staging / Ready for prod | `staging` |
| Prod | `prod` |

The cron runs every 10 min and now overwrites Deploy when it doesn't match the column. `advance-deploy-env` still does the immediate update on push events — this cron is the safety net for everything else.

## Test plan

- [ ] After merge: kick off auto-classify via `workflow_dispatch` → verify zero items mutated (board is now clean)
- [ ] Manually drag an item from `FR on dev` to `Backlog` on the board → wait 10 min → verify Deploy env flips from `dev` to `none`
- [ ] Close an issue as completed → verify Status=`Prod` and Deploy env=`prod` within 10 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)
