### PR TITLE
fix(auto-classify): map Status=Cancelled → Deploy=Cancelled

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -55,6 +55,7 @@ jobs:
           DEPLOY_DEV="2bd56845"
           DEPLOY_STAGING="cadea71b"
           DEPLOY_PROD="4c9dd784"
+          DEPLOY_CANCELLED="9866b58c"
 
           set_field() {
             gh api graphql -f query="
@@ -134,7 +135,7 @@ jobs:
               target=""
               target_name=""
               case "$status" in
-                "Backlog"|"Ready"|"In progress"|"Code review"|"Cancelled"|"")
+                "Backlog"|"Ready"|"In progress"|"Code review"|"")
                   target="$DEPLOY_NONE"; target_name="none" ;;
                 "FR on dev"|"Ready for staging")
                   target="$DEPLOY_DEV"; target_name="dev" ;;
@@ -142,6 +143,8 @@ jobs:
                   target="$DEPLOY_STAGING"; target_name="staging" ;;
                 "Prod")
                   target="$DEPLOY_PROD"; target_name="prod" ;;
+                "Cancelled")
+                  target="$DEPLOY_CANCELLED"; target_name="Cancelled" ;;
               esac
 
               if [ -n "$target" ] && [ "$current_deploy" != "$target_name" ]; then


### PR DESCRIPTION
## Summary

You added a `Cancelled` option to the `Deploy environment` field on the kanban project (so the "Deployment environment" board view can show cancelled items in their own column instead of bucketing them with not-yet-deployed work in `none`).

Updating the auto-classify cron's Status→Deploy mapping to match.

## Mapping (final)

| Status | Deploy environment |
|---|---|
| Backlog / Ready / In progress / Code review | `none` |
| FR on dev / Ready for staging | `dev` |
| FR on staging / Ready for prod | `staging` |
| Prod | `prod` |
| **Cancelled** | **`Cancelled`** ← new |

Already backfilled the 46 existing `Status=Cancelled` items via GraphQL. This PR just makes sure the cron keeps new ones in sync.

## Test plan

- [ ] Open then close a test PR without merging → verify Status=Cancelled and Deploy env=Cancelled within 10 min
- [ ] Close an issue as "Not planned" → verify same

🤖 Generated with [Claude Code](https://claude.com/claude-code)
