### PR TITLE
fix(auto-classify): route Ready/In progress/Code review to Deploy=Active

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -52,6 +52,7 @@ jobs:
 
           # Deploy env option IDs
           DEPLOY_NONE="14e41520"
+          DEPLOY_ACTIVE="386a9edb"
           DEPLOY_DEV="2bd56845"
           DEPLOY_STAGING="cadea71b"
           DEPLOY_PROD="4c9dd784"
@@ -135,8 +136,10 @@ jobs:
               target=""
               target_name=""
               case "$status" in
-                "Backlog"|"Ready"|"In progress"|"Code review"|"")
+                "Backlog"|"")
                   target="$DEPLOY_NONE"; target_name="none" ;;
+                "Ready"|"In progress"|"Code review")
+                  target="$DEPLOY_ACTIVE"; target_name="Active" ;;
                 "FR on dev"|"Ready for staging")
                   target="$DEPLOY_DEV"; target_name="dev" ;;
                 "FR on staging"|"Ready for prod")


### PR DESCRIPTION
## Summary

Adds a new `Active` column to the Deployment environment view, sitting between `none` (untouched backlog) and `dev` (deployed). Captures items that are being worked on right now but not deployed yet — Ready / In progress / Code review.

## Before vs after

**Before:** `none` was a 108-item bucket mixing 89 untouched backlog items + 19 in-flight pieces of work. The pipeline shape was hidden.

**After:**
```
Backlog (89) → Active (~20) → dev (22) → staging (20) → prod (449)    + Cancelled (46)
```

You can now see at a glance: "how much work is actually in flight right now?"

## Status → Deploy mapping (final)

| Status | Deploy environment |
|---|---|
| Backlog | `none` |
| **Ready / In progress / Code review** | **`Active`** ← new |
| FR on dev / Ready for staging | `dev` |
| FR on staging / Ready for prod | `staging` |
| Prod | `prod` |
| Cancelled | `Cancelled` |

## Already done via GraphQL

- Added the `Active` option to the Deploy environment field (ID `386a9edb`, color YELLOW, positioned between `none` and `dev`)
- Backfilled the 20 existing Ready/In progress/Code review items to `Deploy=Active`

This PR just makes the cron keep new items in sync.

## Trade-off (worth flagging)

`Deploy environment` was originally pure "where is this running right now." Active items aren't deployed anywhere, they're just being worked on. We're mixing a small amount of work-stage semantics into the field for the sake of a cleaner board view. I think the trade is worth it — Lukas confirmed.

## Test plan

- [ ] Open a draft PR → verify Status=In progress, Deploy=Active within 10 min
- [ ] Mark a PR ready for review → verify Status=Code review, Deploy=Active
- [ ] Verify Backlog items stay in Deploy=none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
