### PR TITLE
feat(kanban): add North Stars Status column for actively-driven epics

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -138,7 +138,7 @@ jobs:
               case "$status" in
                 "Backlog"|"")
                   target="$DEPLOY_NONE"; target_name="none" ;;
-                "Ready"|"In progress"|"Code review")
+                "North Stars"|"Ready"|"In progress"|"Code review")
                   target="$DEPLOY_ACTIVE"; target_name="Active" ;;
                 "FR on dev"|"Ready for staging")
                   target="$DEPLOY_DEV"; target_name="dev" ;;


### PR DESCRIPTION
## Summary

Adds a new `North Stars` Status column between `Backlog` and `Ready`, so the kanban surfaces the 3-5 epic-typed items the team is currently driving. Reads at a glance as "what's our current strategic focus."

## Why

The board flow currently goes `Backlog → Ready → ...`. Backlog is a 90+ item bucket of "maybe one day", and there's no visible signal for "these are the major initiatives we're actively driving right now." Engineers and stakeholders have to remember the strategic context separately.

Adding a `North Stars` column makes that signal first-class.

## Where it sits

```
Backlog → North Stars → Ready → In progress → Code review → ... → Prod        + Cancelled
```

Reads naturally as escalating immediacy: maybe one day → actively driving → ready to pick up.

## What goes there

Only epic-typed items (`Work Type=Epic`) that the team is *currently* driving. Other epics stay in Backlog. Engineers still pull from `Ready`, not `North Stars` — the column is a visible reminder, not a work queue.

## Deploy environment mapping

`North Stars → Deploy=Active`. Epics aren't deployed themselves, but they're being actively driven. Showing them in the Active deploy column keeps the Deployment environment view coherent (no burying north stars in "none" with untouched backlog).

Already added the Status option via GraphQL (ID `000cdd58`, color YELLOW). This PR just updates the cron to route the mapping.

## Test plan

- [ ] Manually drag an epic-typed issue from `Backlog` to `North Stars` → verify Deploy env flips to `Active` within 10 min
- [ ] Move it back to `Backlog` → verify Deploy env reverts to `none`
- [ ] Verify board layout: Backlog | North Stars | Ready | ... reads left → right

🤖 Generated with [Claude Code](https://claude.com/claude-code)
