### PR TITLE
chore: promote North Stars Status column to main

### DIFF
--- a/.github/workflows/auto-classify.yml
+++ b/.github/workflows/auto-classify.yml
@@ -138,7 +138,7 @@ jobs:
               case "$status" in
                 "Backlog"|"")
                   target="$DEPLOY_NONE"; target_name="none" ;;
-                "Ready"|"In progress"|"Code review")
+                "North Stars"|"Ready"|"In progress"|"Code review")
                   target="$DEPLOY_ACTIVE"; target_name="Active" ;;
                 "FR on dev"|"Ready for staging")
                   target="$DEPLOY_DEV"; target_name="dev" ;;


### PR DESCRIPTION
Carries #50 to main so the cron starts routing North Stars → Active immediately.