### PR TITLE
fix: pass kanban option IDs as raw strings (-f not -F) to survive numeric IDs

### DIFF
--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -148,11 +148,11 @@ jobs:
             fi
 
             echo "→ PR #$prnum: Deploy env = $DEPLOY_ENV"
-            # Pass option IDs with -f (raw string), NOT -F: ProjectV2 option IDs can
-            # be all-numeric (e.g. "FR on dev" = 90729828, "Prod" = 98236657). -F does
-            # magic type coercion, turning an all-digit value into an integer, which
-            # the $o: String! variable then rejects with "Variable $o of type String!
-            # was provided invalid value". -f forces a string and is coercion-proof.
+            # Pass option IDs with -f (raw string), NOT -F: ProjectV2 single-select
+            # option IDs can be all-numeric, and -F does magic type coercion that turns
+            # an all-digit value into an integer, which the $o: String! variable then
+            # rejects ("Variable $o of type String! was provided invalid value").
+            # -f forces a string and is coercion-proof.
             gh api graphql -f query='
               mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
                 updateProjectV2ItemFieldValue(input: {

--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -148,13 +148,18 @@ jobs:
             fi
 
             echo "→ PR #$prnum: Deploy env = $DEPLOY_ENV"
+            # Pass option IDs with -f (raw string), NOT -F: ProjectV2 option IDs can
+            # be all-numeric (e.g. "FR on dev" = 90729828, "Prod" = 98236657). -F does
+            # magic type coercion, turning an all-digit value into an integer, which
+            # the $o: String! variable then rejects with "Variable $o of type String!
+            # was provided invalid value". -f forces a string and is coercion-proof.
             gh api graphql -f query='
               mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
                 updateProjectV2ItemFieldValue(input: {
                   projectId: $p, itemId: $i, fieldId: $f,
                   value: {singleSelectOptionId: $o}
                 }) { projectV2Item { id } }
-              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$DEPLOY_FIELD" -F o="$DEPLOY_OPT" > /dev/null
+              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$DEPLOY_FIELD" -f o="$DEPLOY_OPT" > /dev/null
 
             if [ "${SKIP_STATUS:-0}" != "1" ]; then
               echo "→ PR #$prnum: Status = $STATUS_NAME"
@@ -164,6 +169,6 @@ jobs:
                     projectId: $p, itemId: $i, fieldId: $f,
                     value: {singleSelectOptionId: $o}
                   }) { projectV2Item { id } }
-                }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$STATUS_OPT" > /dev/null
+                }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -f o="$STATUS_OPT" > /dev/null
             fi
           done

--- a/.github/workflows/customer-priority-bump.yml
+++ b/.github/workflows/customer-priority-bump.yml
@@ -79,9 +79,9 @@ jobs:
           fi
 
           # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
-          # be all-numeric (P0 = 79628723 already is), and -F coerces all-digit values
-          # to an integer, which the $o: String! variable rejects. -f forces a string.
-          # P1 happens to contain a letter today, but don't rely on that.
+          # be all-numeric, and -F coerces all-digit values to an integer, which the
+          # $o: String! variable rejects. -f forces a string. (The option set here can
+          # be all-numeric, so this matters even if today's happens to have letters.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {

--- a/.github/workflows/customer-priority-bump.yml
+++ b/.github/workflows/customer-priority-bump.yml
@@ -78,12 +78,16 @@ jobs:
             exit 0
           fi
 
+          # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
+          # be all-numeric (P0 = 79628723 already is), and -F coerces all-digit values
+          # to an integer, which the $o: String! variable rejects. -f forces a string.
+          # P1 happens to contain a letter today, but don't rely on that.
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $p, itemId: $i, fieldId: $f,
                 value: {singleSelectOptionId: $o}
               }) { projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$PRIORITY_FIELD" -F o="$PRIORITY_OPT" > /dev/null
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$PRIORITY_FIELD" -f o="$PRIORITY_OPT" > /dev/null
 
           echo "→ Issue #$ISSUE_NUMBER bumped to Priority=$PRIORITY_NAME"

--- a/.github/workflows/fr-pass-comment.yml
+++ b/.github/workflows/fr-pass-comment.yml
@@ -116,13 +116,18 @@ jobs:
             exit 1
           fi
 
+          # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
+          # be all-numeric, and -F coerces all-digit values to an integer, which the
+          # $o: String! variable rejects. -f forces a string. (Today's "Ready for
+          # staging" / "Ready for prod" IDs happen to contain letters, but don't rely
+          # on that — IDs regenerate if an option is recreated.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $p, itemId: $i, fieldId: $f,
                 value: {singleSelectOptionId: $o}
               }) { projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$NEXT_OPT" > /dev/null
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -f o="$NEXT_OPT" > /dev/null
 
           echo "→ #$NUMBER: $CURRENT → $NEXT"
           echo "result=advanced" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/fr-pass-comment.yml
+++ b/.github/workflows/fr-pass-comment.yml
@@ -118,9 +118,8 @@ jobs:
 
           # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
           # be all-numeric, and -F coerces all-digit values to an integer, which the
-          # $o: String! variable rejects. -f forces a string. (Today's "Ready for
-          # staging" / "Ready for prod" IDs happen to contain letters, but don't rely
-          # on that — IDs regenerate if an option is recreated.)
+          # $o: String! variable rejects. -f forces a string. (Some option IDs contain
+          # letters today, but don't rely on that — IDs regenerate if recreated.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {

--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -82,12 +82,17 @@ jobs:
             exit 0
           fi
 
+          # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
+          # be all-numeric, and -F coerces all-digit values to an integer, which the
+          # $o: String! variable rejects. -f forces a string. (Today's "Code review" /
+          # "In progress" IDs happen to contain letters, but don't rely on that — IDs
+          # regenerate if an option is recreated.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $p, itemId: $i, fieldId: $f,
                 value: {singleSelectOptionId: $o}
               }) { projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$STATUS_OPT" > /dev/null
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -f o="$STATUS_OPT" > /dev/null
 
           echo "→ PR #$PR_NUMBER → Status=$STATUS_NAME"

--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -84,9 +84,8 @@ jobs:
 
           # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
           # be all-numeric, and -F coerces all-digit values to an integer, which the
-          # $o: String! variable rejects. -f forces a string. (Today's "Code review" /
-          # "In progress" IDs happen to contain letters, but don't rely on that — IDs
-          # regenerate if an option is recreated.)
+          # $o: String! variable rejects. -f forces a string. (Some option IDs contain
+          # letters today, but don't rely on that — IDs regenerate if recreated.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {


### PR DESCRIPTION
## Summary

Fixes a real, currently-firing bug in the kanban automation: `advance-deploy-env.yml` crashes on **every** push to `develop` and `master`/`main`.

**Root cause:** the workflows pass single-select option IDs to GraphQL with `gh api graphql -F o="$OPT_ID"`. The `-F` flag does magic type coercion — an all-digit value becomes an **integer** — but the mutation variable is `$o: String!`, which rejects it:

```
gh: Variable $o of type String! was provided invalid value
```

ProjectV2 option IDs are 8-char hex and are frequently all-numeric. Some of the status-transition options this automation targets are all-numeric, so the mutation fails. The Deploy-environment update runs first and succeeds (its option IDs contain letters), then the Status update crashes the job — so the run goes red and the Status field doesn't advance. It's been **masked** because `kanban-closure-router.yml` (a separate PR-merge-triggered workflow) already uses `-f` and advances the card correctly. So cards moved, but the `advance / advance` job has been failing silently.

**Fix:** `-F o=` → `-f o=` (raw string, coercion-proof) in all 5 mutations across 4 workflows. `$p`/`$i`/`$f` stay `-F` — they're GraphQL `ID!` (which accepts integer coercion) and are always letter-prefixed anyway.

| Workflow | Mutations fixed | Was |
|---|---|---|
| `advance-deploy-env.yml` | 2 | actively crashing |
| `set-pr-status.yml` | 1 | latent |
| `fr-pass-comment.yml` | 1 | latent |
| `customer-priority-bump.yml` | 1 | latent |

No change needed in `kanban-closure-router.yml` (already `-f`) or `auto-classify.yml` (inlines the ID as a quoted string literal). Each fix carries a comment explaining the `-f` so it isn't reverted later.

## ⚠️ Activation note

Caller workflows reference these reusables at `@main`, so this fix only takes effect once it reaches `main` via the normal develop → staging → main promotion. Targeting `develop` per branch policy.

## Test plan

- [x] YAML parses (all 4 files)
- [x] No `-F o=` remains; 5× `-f o=` present; `$p`/`$i`/`$f` unchanged
- [ ] After promotion to main: push to develop on any repo → `advance / advance` job is green and the card advances
- [ ] Push to master/main → card advances to the prod state
