### PR TITLE
fix: pass kanban option IDs as raw strings (-f not -F) to survive num…

### DIFF
--- a/.github/workflows/advance-deploy-env.yml
+++ b/.github/workflows/advance-deploy-env.yml
@@ -148,13 +148,18 @@ jobs:
             fi
 
             echo "→ PR #$prnum: Deploy env = $DEPLOY_ENV"
+            # Pass option IDs with -f (raw string), NOT -F: ProjectV2 single-select
+            # option IDs can be all-numeric, and -F does magic type coercion that turns
+            # an all-digit value into an integer, which the $o: String! variable then
+            # rejects ("Variable $o of type String! was provided invalid value").
+            # -f forces a string and is coercion-proof.
             gh api graphql -f query='
               mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
                 updateProjectV2ItemFieldValue(input: {
                   projectId: $p, itemId: $i, fieldId: $f,
                   value: {singleSelectOptionId: $o}
                 }) { projectV2Item { id } }
-              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$DEPLOY_FIELD" -F o="$DEPLOY_OPT" > /dev/null
+              }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$DEPLOY_FIELD" -f o="$DEPLOY_OPT" > /dev/null
 
             if [ "${SKIP_STATUS:-0}" != "1" ]; then
               echo "→ PR #$prnum: Status = $STATUS_NAME"
@@ -164,6 +169,6 @@ jobs:
                     projectId: $p, itemId: $i, fieldId: $f,
                     value: {singleSelectOptionId: $o}
                   }) { projectV2Item { id } }
-                }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$STATUS_OPT" > /dev/null
+                }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -f o="$STATUS_OPT" > /dev/null
             fi
           done

--- a/.github/workflows/customer-priority-bump.yml
+++ b/.github/workflows/customer-priority-bump.yml
@@ -78,12 +78,16 @@ jobs:
             exit 0
           fi
 
+          # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
+          # be all-numeric, and -F coerces all-digit values to an integer, which the
+          # $o: String! variable rejects. -f forces a string. (The option set here can
+          # be all-numeric, so this matters even if today's happens to have letters.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $p, itemId: $i, fieldId: $f,
                 value: {singleSelectOptionId: $o}
               }) { projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$PRIORITY_FIELD" -F o="$PRIORITY_OPT" > /dev/null
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$PRIORITY_FIELD" -f o="$PRIORITY_OPT" > /dev/null
 
           echo "→ Issue #$ISSUE_NUMBER bumped to Priority=$PRIORITY_NAME"

--- a/.github/workflows/fr-pass-comment.yml
+++ b/.github/workflows/fr-pass-comment.yml
@@ -116,13 +116,17 @@ jobs:
             exit 1
           fi
 
+          # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
+          # be all-numeric, and -F coerces all-digit values to an integer, which the
+          # $o: String! variable rejects. -f forces a string. (Some option IDs contain
+          # letters today, but don't rely on that — IDs regenerate if recreated.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $p, itemId: $i, fieldId: $f,
                 value: {singleSelectOptionId: $o}
               }) { projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$NEXT_OPT" > /dev/null
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -f o="$NEXT_OPT" > /dev/null
 
           echo "→ #$NUMBER: $CURRENT → $NEXT"
           echo "result=advanced" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/set-pr-status.yml
+++ b/.github/workflows/set-pr-status.yml
@@ -82,12 +82,16 @@ jobs:
             exit 0
           fi
 
+          # Pass the option ID with -f (raw string), NOT -F: ProjectV2 option IDs can
+          # be all-numeric, and -F coerces all-digit values to an integer, which the
+          # $o: String! variable rejects. -f forces a string. (Some option IDs contain
+          # letters today, but don't rely on that — IDs regenerate if recreated.)
           gh api graphql -f query='
             mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
               updateProjectV2ItemFieldValue(input: {
                 projectId: $p, itemId: $i, fieldId: $f,
                 value: {singleSelectOptionId: $o}
               }) { projectV2Item { id } }
-            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -F o="$STATUS_OPT" > /dev/null
+            }' -F p="$PROJECT_ID" -F i="$ITEM_ID" -F f="$STATUS_FIELD" -f o="$STATUS_OPT" > /dev/null
 
           echo "→ PR #$PR_NUMBER → Status=$STATUS_NAME"


### PR DESCRIPTION
…eric IDs (#52)

* fix: pass ProjectV2 option IDs as raw strings (-f not -F) in kanban mutations

The kanban field automations set single-select option IDs via `gh api graphql -F o="$OPT_ID"`. The -F flag does magic type coercion: an all-numeric value is converted to an integer. The mutation variable is `$o: String!`, which rejects an integer with:

    gh: Variable $o of type String! was provided invalid value

ProjectV2 single-select option IDs are 8-char hex and are frequently all-numeric. Two are today:
  - Status "FR on dev" = 90729828
  - Status "Prod"      = 98236657

advance-deploy-env.yml drives exactly those two transitions, so it has been crashing on every push to develop (-> FR on dev) and master/main (-> Prod). The Deploy-environment update runs first and succeeds (its option IDs contain letters), so that field "half-worked" while the Status update crashed the job. Card advancement was masked by the separate kanban-closure-router.yml, which already uses -f correctly.

Fix: switch the option-ID parameter from -F to -f (raw string) in all five mutations across four workflows. The $p/$i/$f params stay -F: they are GraphQL ID! (which accepts integer coercion) and are always letter-prefixed (PVT_/PVTI_/PVTSSF_) anyway.

  - advance-deploy-env.yml     (2 mutations - actively crashing)
  - set-pr-status.yml          (latent: Code review / In progress have letters)
  - fr-pass-comment.yml        (latent: Ready for * have letters)
  - customer-priority-bump.yml (latent: P1 has a letter; P0 = 79628723 does not)

kanban-closure-router.yml already used -f (no change). auto-classify.yml inlines the option ID as a quoted string literal (no change).

A comment at each call site explains the -f so it is not reverted to -F.

* chore: genericize kanban-fix comments (drop internal IDs/labels)

These reusable workflows live in the public tracebloc/.github repo. Remove the specific option-ID values and column/priority names from the comments added in the previous commit; keep the full technical rationale (option IDs can be all-numeric; -F coerces to int; $o: String! rejects it; use -f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to `gh` CLI argument flags for existing kanban mutations; no application runtime or auth logic is modified.
> 
> **Overview**
> Fixes **GitHub Projects v2** kanban automations that were failing when updating **single-select** fields via `gh api graphql`.
> 
> The option ID variable (`$o: String!`) was passed with **`-F`**, which coerces all-digit values to integers and triggers GraphQL errors. It is now passed with **`-f`** so the value stays a string. **`$p` / `$i` / `$f`** remain **`-F`** (GraphQL `ID!`).
> 
> This change is applied in **five mutations** across **`advance-deploy-env.yml`** (deploy + status on push), **`set-pr-status.yml`**, **`fr-pass-comment.yml`**, and **`customer-priority-bump.yml`**, with short comments at each call site so the flag choice is not reverted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6944510fb9b461611961c00fee844f4804d58d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->