### PR TITLE
fix(fr-gate): pass items at or beyond the required stage

### DIFF
--- a/.github/workflows/fr-gate.yml
+++ b/.github/workflows/fr-gate.yml
@@ -2,10 +2,14 @@ name: FR gate
 
 # Reusable workflow. Called from each active repo on pull_request events
 # targeting staging, main, or master. Blocks the merge unless every item
-# included in the promotion is in the correct "Ready for X" column:
+# included in the promotion is at or beyond the correct "Ready for X" column:
 #
-#   target = staging  → all items must be in "Ready for staging"
-#   target = main/master → all items must be in "Ready for prod"
+#   target = staging  → all items must be at "Ready for staging" or later
+#   target = main/master → all items must be at "Ready for prod" or later
+#
+# "or later" means an item already further down the pipeline (e.g. "Prod")
+# satisfies an earlier gate ("Ready for staging") instead of being falsely
+# blocked. See the rank() helper below for the canonical stage ordering.
 #
 # This enforces the "FR must pass before promotion" rule. It runs as a
 # required status check (configured via branch protection) so the merge
@@ -108,6 +112,28 @@ jobs:
             NUMBERS="$PROMOTION_PR"
           fi
 
+          # Pipeline rank for each kanban Status. An item satisfies the gate when
+          # it is AT OR BEYOND the required stage — e.g. an item already in "Prod"
+          # trivially satisfies a "Ready for staging" gate. Strict equality used to
+          # falsely block already-promoted items that reappear in a later promotion's
+          # commit range. Unknown statuses (incl. "Cancelled") return empty and fall
+          # through to the strict-equality path below, preserving the old behavior.
+          rank() {
+            case "$1" in
+              "Backlog")           echo 1  ;;
+              "North Stars")       echo 2  ;;
+              "Ready")             echo 3  ;;
+              "In progress")       echo 4  ;;
+              "Code review")       echo 5  ;;
+              "FR on dev")         echo 6  ;;
+              "Ready for staging") echo 7  ;;
+              "FR on staging")     echo 8  ;;
+              "Ready for prod")    echo 9  ;;
+              "Prod")              echo 10 ;;
+              *)                   echo "" ;;
+            esac
+          }
+
           BLOCKED=""
           MISSING=""
           PASSED=""
@@ -136,18 +162,24 @@ jobs:
               continue
             fi
 
-            if [ "$STATUS" = "$REQUIRED" ]; then
-              echo "  ✅ #$num — Status='$REQUIRED'"
+            SR=$(rank "$STATUS")
+            RR=$(rank "$REQUIRED")
+            if { [ -n "$SR" ] && [ -n "$RR" ] && [ "$SR" -ge "$RR" ]; } || [ "$STATUS" = "$REQUIRED" ]; then
+              if [ "$STATUS" = "$REQUIRED" ]; then
+                echo "  ✅ #$num — Status='$REQUIRED'"
+              else
+                echo "  ✅ #$num — Status='$STATUS' (beyond '$REQUIRED')"
+              fi
               PASSED="$PASSED #$num"
             else
-              echo "  ❌ #$num — Status='$STATUS', required='$REQUIRED'"
+              echo "  ❌ #$num — Status='$STATUS', required '$REQUIRED' or later"
               BLOCKED="$BLOCKED #$num($STATUS)"
             fi
           done
 
           echo ""
           if [ -n "$BLOCKED" ]; then
-            echo "::error::FR gate FAILED. Items not yet '$REQUIRED':$BLOCKED"
+            echo "::error::FR gate FAILED. Items not yet at '$REQUIRED' (or later):$BLOCKED"
             echo ""
             echo "How to unblock:"
             echo "  1. Run /fr-pass on each PR once functional review passes on the previous env, OR"
@@ -157,7 +189,7 @@ jobs:
             exit 1
           fi
 
-          echo "✓ FR gate PASSED. All items are in '$REQUIRED'."
+          echo "✓ FR gate PASSED. All items are at '$REQUIRED' or later."
           # Use an `if` here, not `[ -n ... ] && echo`. With `set -e`, the bracket
           # test returning 1 on empty MISSING (the normal happy path) would short-
           # circuit && and become the script's exit code, failing the step.


### PR DESCRIPTION
## Summary
The FR gate compared each item's kanban Status to the required stage with **strict equality** (`[ "$STATUS" = "$REQUIRED" ]`). An item already *further down* the pipeline than the gate requires was therefore falsely **blocked** — e.g. a card in `Prod` that reappears in a later staging promotion's commit range fails a `Ready for staging` gate even though it has already shipped past staging.

This replaces the equality check with a **pipeline rank comparison**: an item passes when its stage is **at or beyond** the required stage.

## Change
- Added a `rank()` helper enumerating the canonical kanban stages (Backlog … FR on dev → Ready for staging → FR on staging → Ready for prod → Prod).
- Pass when `rank(status) >= rank(required)`, or on exact match.
- Unknown statuses (including `Cancelled`) return an empty rank and fall through to the original strict-equality check — so they stay **blocked**, preserving prior behavior for anything outside the linear pipeline.
- Updated pass/fail messages and the header doc to "or later".

## Why this is safe
- Items *before* the required stage still block (FR-on-staging vs Ready-for-prod → ❌), so the "FR must pass before promotion" rule is unchanged.
- Only items at or beyond the bar newly pass — which is the correct semantics.

## Test
Verified the comparison locally against the stage matrix:

| Item status | Required | Result |
|---|---|---|
| Prod | Ready for staging | ✅ pass |
| Prod | Ready for prod | ✅ pass |
| Ready for staging | Ready for staging | ✅ pass (exact) |
| FR on staging | Ready for prod | ❌ block |
| FR on dev | Ready for staging | ❌ block |
| Cancelled | Ready for prod | ❌ block (unknown rank → strict eq) |

YAML validated with `yaml.safe_load`.

## Blast radius
Reusable workflow consumed by every repo's `fr-gate-caller` at `@main`. Takes effect org-wide on merge. No input/interface changes — callers need no update.

## Context
Surfaced by tracebloc/averaging-service#115 (staging→main), where the prior develop→staging promotion's CI card (#98) sat in `Prod` and falsely blocked the staging gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-blocking CI semantics org-wide for all promotion PRs; under-stage items still fail, but mis-ordered ranks in `rank()` could incorrectly pass or block gates.
> 
> **Overview**
> The reusable **FR gate** workflow no longer requires an exact kanban **Status** match. Promotion PRs were failing when a linked item’s card had already moved past the gate (e.g. **Prod** in a staging promotion range) because the check used strict equality.
> 
> A **`rank()`** helper maps linear pipeline stages from **Backlog** through **Prod**. An item **passes** when `rank(status) >= rank(required)`; unknown statuses (e.g. **Cancelled**) still use the old exact-match path so they stay blocked. Pass/fail and header comments now say **“or later”**, with clearer logging when an item passes because it is beyond the required stage.
> 
> **Blast radius:** org-wide via reusable `fr-gate` callers; no workflow inputs changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf055067f4d91e6a282f8e58426354582225129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->