### PR TITLE
chore(wip-limit): raise Code-review nudge threshold 8 → 30

### DIFF
--- a/.github/workflows/wip-limit-check.yml
+++ b/.github/workflows/wip-limit-check.yml
@@ -18,7 +18,7 @@ on:
         default: "Code review"
       limit:
         type: number
-        default: 8
+        default: 30
 
 jobs:
   check:


### PR DESCRIPTION
## What

Bumps the `limit` default in the reusable `wip-limit-check.yml` workflow from **8 → 30**.

## Why

The workflow posts a soft "👋 Heads-up — Code review queue is at N / LIMIT" nudge when the kanban **Code review** column is over the WIP limit. At 8 the threshold is too low for current throughput — e.g. [tracebloc-client#390](https://github.com/tracebloc/tracebloc-client/pull/390) was nudged at **19 / 8**. Raising the bucket to 30 means the nudge only fires above 30 in review.

## Scope

Every caller (`tracebloc-client`, `backend`, `client-runtime`, `client`, `cli`, `docs`, `frontend-app`, `tracebloc-website`, `tracebloc-py-package`, `data-ingestors`) uses `uses: tracebloc/.github/.github/workflows/wip-limit-check.yml@main` with `secrets: inherit` and **no `limit` override** — so this one default change applies org-wide.

## Base branch note

Targeting `main` (not `develop`): the reusable workflow is pinned `@main`, and `develop` is currently 8 commits behind `main` with nothing unique — so `main` is the live source and the only base that makes the change take effect with a clean one-line diff.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default value change in a non-blocking CI nudge workflow with no logic or secret handling changes.
> 
> **Overview**
> Raises the default **`limit`** input on the reusable **`wip-limit-check.yml`** workflow from **8** to **30**, so the kanban “Code review” queue nudge only posts when depth is above 30.
> 
> Callers that rely on the default (no `limit` override) pick up the new threshold org-wide; workflow behavior and the nudge comment logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32462b5b3bdbb37654b94716607044626b812626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->