### PR TITLE
fix(wip-limit): avoid sort|head SIGPIPE failing the WIP check when queue >10

### DIFF
--- a/.github/workflows/wip-limit-check.yml
+++ b/.github/workflows/wip-limit-check.yml
@@ -106,7 +106,11 @@ jobs:
               | "- [\($c.repository.name)#\($c.number)](https://github.com/\($org)/\($c.repository.name)/pull/\($c.number)) — \($c.title) · author: @\($c.author.login) · " +
                 ((.content.reviewRequests.nodes | map(.requestedReviewer.login) | map(select(.)) | join(", @")) as $rev
                  | if ($rev | length) > 0 then "reviewer: @\($rev)" else "no reviewer assigned" end)
-            ' /tmp/inreview.txt | sort | head -10
+            ' /tmp/inreview.txt | sort > /tmp/inreview_sorted.txt
+            # NB: don't pipe `sort | head` directly — once head closes the pipe
+            # after 10 lines, sort gets SIGPIPE/EPIPE and exits non-zero, which
+            # under `set -o pipefail` fails the whole step. Sort to a file, then head it.
+            head -10 /tmp/inreview_sorted.txt
             echo ""
             echo "Pull from review before opening new work. _(This is a nudge from the kanban WIP check, not a block.)_"
           } > "$BODY_FILE"


### PR DESCRIPTION
## Problem

The reusable **WIP limit check** (`.github/workflows/wip-limit-check.yml`) fails with exit code 2 for any PR when the *Code review* queue is over the limit **and** has more than 10 items. Seen on [tracebloc-py-package#237](https://github.com/tracebloc/tracebloc-py-package/pull/237) — queue at 36/30:

```
Code review queue depth: 36 (limit: 30)
sort: fflush failed: 'standard output': Broken pipe
sort: write error
##[error]Process completed with exit code 2.
```

## Cause

The over-limit comment path builds its list with:

```bash
jq -r '...' /tmp/inreview.txt | sort | head -10
```

`head -10` closes the pipe after 10 lines; `sort` then hits `EPIPE` on its next write and exits non-zero. Under `set -euo pipefail` that non-zero pipe status fails the whole step. It's a size/timing race — small queues let `sort` flush before `head` closes (why cli's check passed earlier at ≤30), so it only surfaced once the queue grew past 10 *and* over the limit.

## Fix

Sort to a temp file, then `head` the file — `sort` never shares a pipe with a short-circuiting reader, so the broken pipe can't happen regardless of queue size. Output is unchanged (still the 10 oldest, sorted). The over-limit nudge comment now posts and the step exits 0.

## Impact

This reusable workflow is called by every repo's PR CI, so the fix unblocks the WIP check fleet-wide. tracebloc-py-package#237's check stays red until this merges to `main` (its caller pins `@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only bash change in the over-limit comment path; no app, auth, or data handling impact.
> 
> **Overview**
> When the Code review queue is over the WIP limit and has more than 10 PRs, the reusable **WIP limit check** workflow could fail the step instead of posting its nudge comment. The over-limit path listed PRs with `jq … | sort | head -10`; with `set -o pipefail`, `head` closing the pipe after 10 lines made `sort` exit on **EPIPE**, so the job failed (e.g. exit code 2) even though the check is meant to be non-blocking.
> 
> The workflow now **writes the sorted list to `/tmp/inreview_sorted.txt`**, then runs **`head -10`** on that file, so `sort` is not piped to a short-circuiting reader. Comment content is unchanged (still up to 10 oldest queue entries). A short comment in the YAML documents why `sort | head` must not be used here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0dc8a5b9ec2c6c345ee5c8d4bf05db1423ca8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->