### PR TITLE
fix(pii-gate): run under restrictive default token perms (contents-scoped Compare API)

### DIFF
--- a/.github/workflows/public-pii-gate.yml
+++ b/.github/workflows/public-pii-gate.yml
@@ -16,13 +16,19 @@ name: Public PII gate
 #
 # Override a false positive: add the 'pii-gate-override' label to the PR
 # (visible in audit).
+#
+# Token permissions: this workflow needs only `contents: read`. It reads
+# commit messages via the Compare API (contents-scoped), NOT the Pull
+# requests API, so it works under the org default workflow-token permission
+# of "read" with a minimal caller (just `uses:` + `secrets: inherit`).
+# Requesting `pull-requests` here would exceed a minimal caller's grant and
+# fail the run at startup with no jobs.
 
 on:
   workflow_call: {}
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   pii-check:
@@ -34,7 +40,8 @@ jobs:
           DENYLIST: ${{ secrets.PII_DENYLIST }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO_FULL: ${{ github.repository }}
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
@@ -54,8 +61,10 @@ jobs:
           fi
 
           # Build the haystack: PR title + body + every commit message.
-          COMMITS=$(gh pr view "$PR_NUM" --repo "$REPO_FULL" \
-            --json commits --jq '.commits[] | .messageHeadline + " " + (.messageBody // "")' 2>/dev/null || true)
+          # Commits come from the Compare API (contents-scoped). It returns up
+          # to 250 commits, which is ample for PR-hygiene scanning.
+          COMMITS=$(gh api "repos/$REPO_FULL/compare/$PR_BASE_SHA...$PR_HEAD_SHA" \
+            --jq '.commits[].commit.message' 2>/dev/null || true)
           HAYSTACK=$(printf '%s\n%s\n%s' "${PR_TITLE:-}" "${PR_BODY:-}" "$COMMITS")
 
           # Check each denylist term (comma-separated). Never echo the term or


### PR DESCRIPTION
## Problem
After publishing \`public-pii-gate.yml\` to main (#60), the **Public PII gate** still failed at startup with **0 jobs** on every PR in adopting repos (cli, data-ingestors).

Root cause: the reusable workflow declared \`permissions: { contents: read, pull-requests: read }\`, but those repos' **default workflow token permission is "read"** (grants \`contents\`/\`packages\` read; \`pull-requests: none\`). A minimal caller (\`uses:\` + \`secrets: inherit\`, no \`permissions:\` block) therefore cannot grant \`pull-requests\`, so the called workflow's request exceeds the caller's ceiling → startup failure, no jobs.

## Fix
Make the reusable workflow self-sufficient under the restrictive default so callers stay trivial (no per-repo \`permissions:\` block, no recurring footgun):
- Read commit messages via the **Compare API** (\`repos/{repo}/compare/{base}...{head}\`), which is **contents-scoped**, instead of \`gh pr view --json commits\` (pull-requests-scoped).
- Request only \`permissions: contents: read\` (least privilege).

Title/body/labels already come from the event payload (no API). Full scan coverage (title + body + commit messages) is preserved.

## Verification
On a test PR in tracebloc/cli with an **unmodified minimal caller** pointed at this branch, the gate ran green (jobs executed, no startup failure) — run 27748465192. Before the fix, identical minimal callers @main produced 0-job startup failures.

Tracking: #62

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission and API change for PR text scanning; same haystack sources with a documented 250-commit Compare API cap.
> 
> **Overview**
> Fixes reusable **Public PII gate** workflows that failed at startup with **0 jobs** when called from repos whose default `GITHUB_TOKEN` only grants `contents: read` (no `pull-requests`).
> 
> The workflow now requests **`permissions: contents: read` only** (drops `pull-requests: read`) and loads commit messages via the **Compare API** (`repos/.../compare/{base}...{head}`) using `PR_BASE_SHA` / `PR_HEAD_SHA` from the event, instead of `gh pr view --json commits`. PR title, body, and labels still come from the payload; scan coverage is unchanged.
> 
> Header comments document why `pull-requests` must not be requested and the 250-commit Compare API limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fad0d9da5d6e7ab098b3718602704c5c4991375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->